### PR TITLE
[TASK] Fix problems with MySQL strict mode

### DIFF
--- a/Configuration/TCA/tx_beacl_acl.php
+++ b/Configuration/TCA/tx_beacl_acl.php
@@ -27,6 +27,7 @@ return [
 				],
 				'size' => 1,
 				'maxitems' => 1,
+                'default' => 0,
 			]
 		],
 		'object_id' => [
@@ -39,6 +40,7 @@ return [
 				'size' => 1,
 				'minitems' => 0,
 				'maxitems' => 1,
+                'default' => 0,
 			]
 		],
 		'permissions' => [
@@ -60,7 +62,8 @@ return [
 			'exclude' => 1,
 			'label' => 'LLL:EXT:be_acl/Resources/Private/Languages/locallang_db.xlf:tx_beacl_acl.recursive',
 			'config' => [
-				'type' => 'check'
+				'type' => 'check',
+                'default' => 0,
 			]
 		],
 	],

--- a/Configuration/TCA/tx_beacl_acl.php
+++ b/Configuration/TCA/tx_beacl_acl.php
@@ -27,7 +27,7 @@ return [
 				],
 				'size' => 1,
 				'maxitems' => 1,
-                'default' => 0,
+                		'default' => 0,
 			]
 		],
 		'object_id' => [
@@ -40,7 +40,7 @@ return [
 				'size' => 1,
 				'minitems' => 0,
 				'maxitems' => 1,
-                'default' => 0,
+                		'default' => 0,
 			]
 		],
 		'permissions' => [
@@ -63,7 +63,7 @@ return [
 			'label' => 'LLL:EXT:be_acl/Resources/Private/Languages/locallang_db.xlf:tx_beacl_acl.recursive',
 			'config' => [
 				'type' => 'check',
-                'default' => 0,
+                		'default' => 0,
 			]
 		],
 	],


### PR DESCRIPTION
When MySQL strict mode is enabled it is not possible to save new ACL entries. Solution is to add a default value to columns with integer values. See https://stackoverflow.com/questions/40542151/typo3-sql-error-incorrect-integer-value-for-column-sys-language-uid-at